### PR TITLE
Managment Group script fails to run on AzureDevOps #5

### DIFF
--- a/azure-pipeline.yaml
+++ b/azure-pipeline.yaml
@@ -18,20 +18,20 @@ variables:
   serviceConnection: 'infra-demo'
 
 stages:
-#  - stage: ManagementGroup
-#    displayName: "Create or Update Management Group Task"
-#    jobs:
-#      - job: ManagementGroupScript
-#        pool:
-#          vmImage: $(vmImage)
-#        steps:
-#          - task: AzurePowerShell@4
-#            displayName: Run Management Group Task
-#            inputs:
-#              azureSubscription: $(serviceConnection)
-#              scriptType: 'filePath'
-#              scriptPath: './scripts/mgmtGroup.ps1'
-#              azurePowerShellVersion: latestVersion
+  - stage: ManagementGroup
+    displayName: "Create or Update Management Group Task"
+    jobs:
+      - job: ManagementGroupScript
+        pool:
+          vmImage: $(vmImage)
+        steps:
+          - task: AzurePowerShell@4
+            displayName: Run Management Group Task
+            inputs:
+              azureSubscription: $(serviceConnection)
+              scriptType: 'filePath'
+              scriptPath: './scripts/mgmtGroup.ps1'
+              azurePowerShellVersion: latestVersion
 
 
   - stage: LZBlueprint

--- a/mgmtGroup/management.json
+++ b/mgmtGroup/management.json
@@ -5,6 +5,9 @@
         "name": "RootLevel"
       },
       {
+        "name": "Test"
+      },
+      {
         "name": "Management",
         "parent": "RootLevel",
         "subscriptionId": "42fd229c-db07-42d3-be34-bc5c98826bc2"

--- a/scripts/mgmtGroup.ps1
+++ b/scripts/mgmtGroup.ps1
@@ -10,8 +10,14 @@ function New-MgmtGroup
     foreach($obj in $loadVars.MgmtGroup.GroupName){
         if ($mgmtGroups -notcontains $obj.name) {
             if($obj.parent -eq $null) {
-                Write-Host "Creating New Management Group"
-                New-AzManagementGroup -GroupName $obj.name
+                Write-Host "Creating New Management Group $($obj.name)"
+                try{
+                    New-AzManagementGroup -GroupName $obj.name -ErrorAction Stop
+                }
+                catch {
+                    Write-Host $_.Exception.Message
+                }
+
 
              if($obj.subscriptionId -ne $null) {
                  Write-Host "Moving $($obj.subscriptionName) to $($obj.Name)"

--- a/scripts/mgmtGroup.ps1
+++ b/scripts/mgmtGroup.ps1
@@ -4,8 +4,6 @@ function New-MgmtGroup
     $file = (Get-ChildItem -Path "./mgmtGroup" | Where-Object {$_.Extension -eq ".json"})
     $loadVars = Get-Content -Path $file.FullName | ConvertFrom-Json
     $mgmtGroups = (Get-AzManagementGroup).DisplayName
-    Write-Host "List of Management Groups" + $mgmtGroups
-    Write-Host "JSON Object Set ..... +" $loadVars.MgmtGroup.GroupName
 
     foreach($obj in $loadVars.MgmtGroup.GroupName){
         if ($mgmtGroups -notcontains $obj.name) {
@@ -30,11 +28,24 @@ function New-MgmtGroup
                 $mgmtGroups = (Get-AzManagementGroup).DisplayName
                 if($mgmtGroups -notcontains $obj.parent) {
                     Write-Host "Creating Parent Management Group"
-                    New-AzManagementGroup -GroupName $obj.name
+                    try{
+                        New-AzManagementGroup -GroupName $obj.name
+                    }
+                    catch  {
+                        Write-Host $_.Exception.Message
+                    }
                 }
                 Write-Host "Creating New Management Group Child"
                 $parentObject = Get-AzManagementGroup -GroupName $obj.parent
-                New-AzManagementGroup -GroupName $obj.Name -ParentObject $parentObject
+                try
+                {
+                    New-AzManagementGroup -GroupName $obj.Name -ParentObject $parentObject
+                }
+                catch
+                {
+                    Write-Host $_.Exception.Message
+                }
+
 
                 if($obj.subscriptionId -ne $null) {
                     Write-Host "Moving $($obj.subscriptionName) to $($obj.Name) Group"

--- a/scripts/mgmtGroup.ps1
+++ b/scripts/mgmtGroup.ps1
@@ -40,7 +40,5 @@ function New-MgmtGroup
 
     }
 }
-Install-Module Az.Resources -Force -AllowClobber -RequiredVersion 1.13.0
-Import-Module Az.Resources
-Get-Module Az.Resources
-#New-MgmtGroup
+
+New-MgmtGroup


### PR DESCRIPTION
Based on the error when running Management Group script there is bug on the cmlet `New-AzManagementGroup` though the cmdlet runs successfully it stills throw the exception which then breaks the. pipeline. To resolve this try & catch block was added to stop the. exception being thrown and continue to run the powershell script.